### PR TITLE
Comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,12 +24,11 @@
 
           <h3>Choose a Google Drive file</h3>
 
-          <ul class="files" data-bind="foreach: files">
-            <li>
-              <a data-bind="text: name, click: $root.onFileChoose">
-              </a>
-            </li>
-          </ul>
+          <div class="list-group" data-bind="foreach: files">
+            <button
+              data-bind="text: name, click: $root.onFileChoose, css: {'list-group-item-info': name === $root.file()}"
+              type="button" class="list-group-item"></button>
+          </div>
 
           <nav>
             <ul class="pager">
@@ -46,25 +45,34 @@
         </div>
 
         <div class="col-sm-8" data-bind="visible: file">
-          <h3 data-bind="text: file"></h3>
+          <h3>Revisors & Commenters</h3>
 
           <p data-bind="text: fileMsg"></p>
 
           <div data-bind="visible: !fileMsg()">
-            This file has <span data-bind="text: revisors().length">?</span> revisors.
+            This file has <span data-bind="text: revisors().length">?</span> revisors:
           </div>
-
           <ol data-bind="foreach: revisors">
             <li>
-              <span data-bind="text: email"></span> made
+              <span data-bind="text: email || name"></span> made
               <span data-bind="text: count"></span> revisions
+            </li>
+          </ol>
+
+          <div data-bind="visible: !fileMsg()">
+            and <span data-bind="text: commenters().length">?</span> commenters:
+          </div>
+          <ol data-bind="foreach: commenters">
+            <li>
+              <span data-bind="text: email || name"></span> wrote
+              <span data-bind="text: count"></span> comments
             </li>
           </ol>
         </div>
 
         <div class="col-sm-8" data-bind="visible: revisors().length > 0">
           <p>as a csv:</p>
-          <pre data-bind="text: revisorsCSV"></pre>
+          <pre data-bind="text: csv"></pre>
         </div>
       </div>
 

--- a/index.js
+++ b/index.js
@@ -196,6 +196,11 @@ function VM() {
       fileId: file.id,
       fields: 'revisions(id,lastModifyingUser)',
     }).execute(function (reply) {
+      // User might have already switched files, so double check
+      if (file.name != this.file()) {
+        return
+      }
+
       console.log('Revisions reply:', reply);
       if (!reply || reply.code || !reply.revisions) {
         this.fileMsg('Failed to get info about file: ' + reply.message);
@@ -235,6 +240,11 @@ function VM() {
   }.bind(this);
 
   this.getCommenters = function (file, pageToken, commentersSoFar) {
+    // User might have already switched files, so double check
+    if (file.name != this.file()) {
+      return
+    }
+
     // On first call, clear old commenters
     if (!pageToken) {
       this.commenters.removeAll();
@@ -251,6 +261,11 @@ function VM() {
       pageSize: 100,
       pageToken: pageToken,
     }).execute(function (reply) {
+      // User might have already switched files, so double check
+      if (file.name != this.file()) {
+        return
+      }
+
       console.log('Comments reply:', reply);
       if (!reply || reply.code || !reply.comments) {
         this.fileMsg('Failed to get comments for file: ' + reply.message);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var Consts = {
   ClientID: '1053866203947-gc9nbfu9tgk5s995p8hikfv83mb66dgo.apps.googleusercontent.com',
   Scopes: [
-    'https://www.googleapis.com/auth/drive.metadata.readonly',
+    'https://www.googleapis.com/auth/drive.readonly',
   ],
 };
 
@@ -13,6 +13,40 @@ function onGoogleAPILoad() {
     window.VM.init();
   }
 };
+
+function incrementRevision(revision, counts) {
+  if (!revision || !revision.lastModifyingUser) {
+    return
+  }
+
+  var email = revision.lastModifyingUser.emailAddress;
+  var name = revision.lastModifyingUser.displayName;
+  var author = email || name;
+  if (!author) {
+    return
+  }
+
+  var entry = counts[author] || {email: email, name: name, count: 0};
+  entry.count += 1;
+  counts[author] = entry;
+}
+
+function incrementComment(comment, counts) {
+  if (!comment || !comment.author) {
+    return
+  }
+
+  var email = comment.author.emailAddress;
+  var name = comment.author.displayName;
+  var author = email || name;
+  if (!author) {
+    return
+  }
+
+  var entry = counts[author] || {email: email, name: name, count: 0};
+  entry.count += 1;
+  counts[author] = entry;
+}
 
 function VM() {
   // Use a msg to debug user issues
@@ -31,19 +65,56 @@ function VM() {
   this.fileMsg = ko.observable('');
 
   this.revisors = ko.observableArray();
-  this.revisorsCSV = ko.computed(function () {
-    var csv = '#email,revision_count\n';
-    var revisors = this.revisors();
+  this.commenters = ko.observableArray();
+  this.contributors = ko.computed(function () {
+    // Combine revisors & commenters
 
+    var contributors = {};
 
-    for (var i=0; i < revisors.length; i++) {
-      var row = (
-          '' + revisors[i].email +
-          ',' + revisors[i].count +
-          (i < revisors.length - 1 ? '\n' : ''));
-      csv = csv + row;
+    // Add commenters first, cuz we tend to have less info about them, so if
+    // we add them first, we can look up by either name or email when we add
+    // revisors.
+    this.commenters().forEach(function (commenter) {
+      // Favor email, but fall back to name
+      contributors[commenter.email || commenter.name] = {
+        email: commenter.email || '',
+        name: commenter.name || '',
+        revisions: 0,
+        comments: commenter.count,
+      };
+    });
+
+    this.revisors().forEach(function (revisor) {
+      // Favor email, but fall back to name
+      var key = (contributors[revisor.email] || !contributors[revisor.name]) ? revisor.email : revisor.name;
+      if (!contributors[key]) {
+        contributors[key] = {revisions: 0, comments: 0};
+      }
+      contributors[key].revisions += revisor.count;
+      contributors[key].email = contributors[key].email || revisor.email;
+      contributors[key].name = contributors[key].name || revisor.name;
+    });
+
+    var asArray = [];
+    for (var key in contributors) {
+      asArray.push(contributors[key]);
     }
+    return asArray.sort(function (a, b) {
+      return b.count - a.count;
+    });
+  }.bind(this));
 
+  this.csv = ko.computed(function () {
+    var csv = '#email,name,revisions,comments\n';
+    this.contributors().forEach(function (contributor, index) {
+      var row = (
+          '' + contributor.email +
+          ',' + contributor.name +
+          ',' + contributor.revisions +
+          ',' + contributor.comments +
+          '\n');
+      csv = csv + row;
+    });
     return csv;
   }.bind(this));
 
@@ -119,6 +190,8 @@ function VM() {
     this.revisors.removeAll();
     this.file(file.name);
 
+    this.getCommenters(file);
+
     gapi.client.drive.revisions.list({
       fileId: file.id,
       fields: 'revisions(id,lastModifyingUser)',
@@ -130,22 +203,14 @@ function VM() {
       }
       this.fileMsg('');
 
-      var revisors = {};
+      var revisionCounts = {};
+      reply.revisions.forEach(function (rev) {
+        incrementRevision(rev, revisionCounts);
+      });
+      console.log('rev counts:', revisionCounts);
 
-      for (var i=0; i < reply.revisions.length; i++) {
-        var rev = reply.revisions[i];
-        var email = (
-            rev && rev.lastModifyingUser &&
-            rev.lastModifyingUser.emailAddress);
-        var count = email && revisors[email] || 0;
-        if (email) {
-          revisors[email] = count + 1;
-        }
-      }
-      console.log('Revisors:', revisors);
-
-      for (var email in revisors) {
-        this.revisors.push({email: email, count: revisors[email]});
+      for (var key in revisionCounts) {
+        this.revisors.push(revisionCounts[key]);
       }
       this.revisors.sort(function (a, b) {
         return b.count - a.count;
@@ -167,6 +232,58 @@ function VM() {
     this.nextPageToken(null);
 
     this.listFiles();
+  }.bind(this);
+
+  this.getCommenters = function (file, pageToken, commentersSoFar) {
+    // On first call, clear old commenters
+    if (!pageToken) {
+      this.commenters.removeAll();
+    }
+
+    if (!commentersSoFar) {
+      commentersSoFar = [];
+    }
+
+    gapi.client.drive.comments.list({
+      fileId: file.id,
+      fields: 'nextPageToken,comments(author(displayName,emailAddress),replies(author(displayName,emailAddress)))',
+      includeDeleted: true,
+      pageSize: 100,
+      pageToken: pageToken,
+    }).execute(function (reply) {
+      console.log('Comments reply:', reply);
+      if (!reply || reply.code || !reply.comments) {
+        this.fileMsg('Failed to get comments for file: ' + reply.message);
+        return
+      }
+
+      // Update commenter counts
+      reply.comments.forEach(function (comment) {
+        // Comment might have an author
+        incrementComment(comment, commentersSoFar);
+
+        // If comment has replies (single list, no sub-replies), then also
+        // increment those authors
+        comment.replies.forEach(function (reply) {
+          incrementComment(reply, commentersSoFar);
+        });
+      });
+
+      if (reply.nextPageToken) {
+        // More to fetch
+        this.getCommenters(file, reply.nextPageToken, commentersSoFar);
+      } else {
+        // Done iterating comments
+        console.log('Commenters:', commentersSoFar);
+        for (var author in commentersSoFar) {
+          this.commenters.push(commentersSoFar[author]);
+        }
+        this.commenters.sort(function (a, b) {
+          return b.count - a.count;
+        });
+      }
+    }.bind(this));
+
   }.bind(this);
 };
 


### PR DESCRIPTION
Combines revision counts with comment counts.

I don't have access to the documents to really verify that this works, but when I tried it on my personal docs, which don't have a lot of revisers & commenters, I found that sometimes Google's APIs don't tell me a commenter's email. I try to join the revisers & commenters on `displayName` where I have the data, but it's not always there.

I also updated the CSV to include email, name, # revisions, and # comments.
